### PR TITLE
define openshift job template

### DIFF
--- a/openshift/tf-executor.template.yaml
+++ b/openshift/tf-executor.template.yaml
@@ -20,12 +20,9 @@ objects:
           command: ["/bin/sh", "-c"]
           args:
           - |
-            echo ${REPO_TARGET_CONFIG} > ${REPO_TARGET_CONFIG_PATH}
-          env:
-          - name: REPO_TARGET_CONFIG
-            value: ${REPO_TARGET_CONFIG}
-          - name: REPO_TARGET_CONFIG_PATH
-            value: ${REPO_TARGET_CONFIG_PATH}
+            cat > ${REPO_TARGET_CONFIG_PATH} <<EOF
+            ${REPO_TARGET_CONFIG}
+            EOF
           resources:
             requests:
               memory: 10Mi
@@ -77,7 +74,7 @@ parameters:
 - name: IMAGE
   value: quay.io/app-sre/terraform-repo-executor
   displayName: terraform repo executor image
-  description: terraform-repo-executor docker image. Defaults to quay.io/app-sre/terraform-rpeo-executor
+  description: terraform-repo-executor docker image. Defaults to quay.io/app-sre/terraform-repo-executor
 - name: IMAGE_TAG
   value: latest
   displayName: terraform-repo-executor version

--- a/openshift/tf-executor.template.yaml
+++ b/openshift/tf-executor.template.yaml
@@ -24,6 +24,8 @@ objects:
           env:
           - name: REPO_TARGET_CONFIG
             value: ${REPO_TARGET_CONFIG}
+          - name: REPO_TARGET_CONFIG_PATH
+            value: ${REPO_TARGET_CONFIG_PATH}
           resources:
             requests:
               memory: 10Mi

--- a/openshift/tf-executor.template.yaml
+++ b/openshift/tf-executor.template.yaml
@@ -96,7 +96,7 @@ parameters:
 - name: REPO_TARGET_CONFIG # supplied by qr int
   value: ''
 - name: REPO_TARGET_CONFIG_PATH
-  value: '/config.yaml'
+  value: '/config.json'
 - name: WORKDIR
   value: '/tf-repo'
 - name: TF_EXECUTOR_SECRET_NAME

--- a/openshift/tf-executor.template.yaml
+++ b/openshift/tf-executor.template.yaml
@@ -1,0 +1,104 @@
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: terraform-repo-executor
+objects:
+- apiVersion: batch/v1
+  kind: Job
+  metadata:
+    name: terraform-repo-executor
+  spec:
+    template:
+      spec:
+        serviceAccountName: terraform-repo-executor
+        restartPolicy: Never
+        initContainers:
+        - name: config-init
+          image: ${BUSYBOX_IMAGE}:${BUSYBOX_IMAGE_TAG}
+          imagePullPolicy: ${BUSYBOX_IMAGE_PULL_POLICY}
+          command: ["/bin/sh", "-c"]
+          args:
+          - |
+            echo ${REPO_TARGET_CONFIG} > ${REPO_TARGET_CONFIG_PATH}
+          env:
+          - name: REPO_TARGET_CONFIG
+            value: ${REPO_TARGET_CONFIG}
+          resources:
+            requests:
+              memory: 10Mi
+              cpu: 15m
+            limits:
+              memory: 20Mi
+              cpu: 25m
+        containers:
+        - name: terraform-repo-executor
+          image: ${IMAGE}:${IMAGE_TAG}
+          env:
+          - name: CONFIG_FILE
+            value: ${REPO_TARGET_CONFIG_PATH}
+          - name: WORKDIR
+            value: ${WORKDIR}
+          - name: VAULT_ADDR
+            valueFrom:
+              secretKeyRef:
+                key: addr
+                name: ${TF_EXECUTOR_SECRET_NAME}
+          - name: VAULT_ROLE_ID
+            valueFrom:
+              secretKeyRef:
+                key: role.id
+                name: ${TF_EXECUTOR_SECRET_NAME}
+          - name: VAULT_SECRET_ID
+            valueFrom:
+              secretKeyRef:
+                key: secret.id
+                name: ${TF_EXECUTOR_SECRET_NAME}
+          - name: GITLAB_USERNAME
+            valueFrom:
+              secretKeyRef:
+                key: gitlab.username
+                name: ${TF_EXECUTOR_SECRET_NAME}
+          - name: GITLAB_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: gitlab.token
+                name: ${TF_EXECUTOR_SECRET_NAME}
+          resources:
+            requests:
+              memory: ${MEMORY_REQUESTS}
+              cpu: ${CPU_REQUESTS}
+            limits:
+              memory: ${MEMORY_LIMIT}
+              cpu: ${CPU_LIMIT}
+parameters:
+- name: IMAGE
+  value: quay.io/app-sre/terraform-repo-executor
+  displayName: terraform repo executor image
+  description: terraform-repo-executor docker image. Defaults to quay.io/app-sre/terraform-rpeo-executor
+- name: IMAGE_TAG
+  value: latest
+  displayName: terraform-repo-executor version
+  description: terraform-repo-executor version which defaults to latest
+- name: BUSYBOX_IMAGE
+  value: quay.io/app-sre/ubi8-ubi-minimal
+- name: BUSYBOX_IMAGE_TAG
+  value: latest
+- name: BUSYBOX_IMAGE_PULL_POLICY
+  value: Always
+- name: MEMORY_REQUESTS
+  value: 150Mi
+- name: MEMORY_LIMIT
+  value: 250Mi
+- name: CPU_REQUESTS
+  value: 100m
+- name: CPU_LIMIT
+  value: 200m
+- name: REPO_TARGET_CONFIG # supplied by qr int
+  value: ''
+- name: REPO_TARGET_CONFIG_PATH
+  value: '/config.yaml'
+- name: WORKDIR
+  value: '/tf-repo'
+- name: TF_EXECUTOR_SECRET_NAME
+  value: tf-repo-executor-creds


### PR DESCRIPTION
Defines a template to be utilized by qr integration and `oc process` to invoke instances of executor. Creation of secret and service account will be handled within app-interface. 

Only parameter that requires population by qr int is `REPO_TARGET_CONFIG`, which will be the yaml-format parameters for the target repository.