### PR TITLE
remove git auth and module logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,14 +28,7 @@ The application processes the yaml/json defined at `CONFIG_FILE` for determining
 | `delete`           | boolean | If `true`, the application will execute the terraform action with the `destroy` flag set                |
 | `secret`     | object  | Vault secret where the terraform credentials for specified account are stored.                        |
 | &emsp;`path` | string  | Path to the secret in the vault. For KV v2, do not include the hidden `data` path segment                                                                               |
-| &emsp;`version` | integer | Version of the secret to b used.                                                                   |
-| `modules`     | list(object)  | List of dependency modules to retrieve and package locally when processing repo target.                        |
-| &emsp;`name` | string | Name of module. This is utilized when specifying `source` in the tf file. **unique within a tf-repo module list**             |
-| &emsp;`url` | string | Url of git repo where module is defined.                |
-| &emsp;`ref`              | string  | Commit sha in the repository to be targeted.                           |
-
-
-
+| &emsp;`version` | integer | Version of the secret to be used.                                                                              |
 
 ### Example
 ``` 
@@ -48,8 +41,4 @@ delete: false
 secret:
   path: terraform/creds/prod-acount
   version: 4
-modules:
-  name: foo
-  url: https://gitlab.myinstance.com/some-gl-group/my-modules
-  ref: 44s3b3cb292d91ec2eb26fc282d75155508881cce
 ```

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@ An application for performing terraform operations of target git repositories.
 
 ## Environment Variables
 ### Required
-* `GITLAB_USERNAME`
-* `GITLAB_TOKEN`
 * `VAULT_ADDR`
 * `VAULT_ROLE_ID`
 * `VAULT_SECRET_ID`

--- a/main.go
+++ b/main.go
@@ -20,16 +20,12 @@ const (
 func main() {
 	cfgPath := getEnvOrDefault(CONFIG_FILE, "/config.yaml")
 	workdir := getEnvOrDefault(WORKDIR, "/tf-repo")
-	glUsername := getEnvOrError(GL_USERNAME)
-	glToken := getEnvOrError(GL_TOKEN)
 	vaultAddr := getEnvOrError(VAULT_ADDR)
 	roleId := getEnvOrError(VAULT_ROLE_ID)
 	secretId := getEnvOrError(VAULT_SECRET_ID)
 
 	err := pkg.Run(cfgPath,
 		workdir,
-		glUsername,
-		glToken,
 		vaultAddr,
 		roleId,
 		secretId,

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -24,8 +24,6 @@ type VaultSecret struct {
 type Executor struct {
 	TfRepoCfg     *TfRepo
 	vaultClient   *vault.Client
-	glUsername    string
-	glToken       string
 	workdir       string
 	vaultAddr     string
 	vaultRoleId   string
@@ -34,8 +32,6 @@ type Executor struct {
 
 func Run(cfgPath,
 	workdir,
-	glUsername,
-	glToken,
 	vaultAddr,
 	roleId,
 	secretId string) error {
@@ -56,8 +52,6 @@ func Run(cfgPath,
 	e := &Executor{
 		TfRepoCfg:     targetRepo,
 		vaultClient:   initVaultClient(vaultAddr, roleId, secretId),
-		glUsername:    glUsername,
-		glToken:       glToken,
 		workdir:       workdir,
 		vaultAddr:     vaultAddr,
 		vaultRoleId:   roleId,

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -7,25 +7,18 @@ import (
 )
 
 type TfRepo struct {
-	Name    string      `yaml:"name" json:"name"`
-	Url     string      `yaml:"repository" json:"repository"`
-	Path    string      `yaml:"project_path" json:"project_path"`
-	Ref     string      `yaml:"ref" json:"ref"`
-	Delete  bool        `yaml:"delete" json:"delete"`
-	DryRun  bool        `yaml:"dry_run" json:"dry_run"`
-	Secret  VaultSecret `yaml:"secret" json:"secret"`
-	Modules []Module    `yaml:"modules" json:"modules"`
+	Name   string      `yaml:"name" json:"name"`
+	Url    string      `yaml:"repository" json:"repository"`
+	Path   string      `yaml:"project_path" json:"project_path"`
+	Ref    string      `yaml:"ref" json:"ref"`
+	Delete bool        `yaml:"delete" json:"delete"`
+	DryRun bool        `yaml:"dry_run" json:"dry_run"`
+	Secret VaultSecret `yaml:"secret" json:"secret"`
 }
 
 type VaultSecret struct {
 	Path    string `yaml:"path" json:"path"`
 	Version int    `yaml:"version" json:"version"`
-}
-
-type Module struct {
-	Name string `yaml:"name" json:"name"`
-	Url  string `yaml:"url" json:"url"`
-	Ref  string `yaml:"ref" json:"ref"`
 }
 
 type Executor struct {
@@ -85,7 +78,7 @@ type errObj struct {
 
 // performs all repo-specific operations
 func (e *Executor) execute() error {
-	err := e.cloneRepo(e.TfRepoCfg.Url, e.TfRepoCfg.Name, e.TfRepoCfg.Ref, e.workdir)
+	err := e.cloneRepo()
 	if err != nil {
 		return err
 	}
@@ -104,13 +97,6 @@ func (e *Executor) execute() error {
 	err = e.generateTfVarsFile(TfBackend)
 	if err != nil {
 		return err
-	}
-
-	if len(e.TfRepoCfg.Modules) > 0 {
-		err = e.getModules()
-		if err != nil {
-			return err
-		}
 	}
 
 	err = e.processTfPlan()

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -1,43 +1,21 @@
 package pkg
 
 import (
-	"errors"
 	"fmt"
-	"net/url"
-	"strings"
 )
 
 func (e *Executor) cloneRepo() error {
-	authUrl, err := e.getAuthUrl(e.TfRepoCfg.Url)
-	if err != nil {
-		return err
-	}
-
 	args := []string{"-c", fmt.Sprintf(
 		// clone repo with specified name and checkout specified ref
 		"git clone %s %s && cd %s && git checkout %s",
-		authUrl,
+		e.TfRepoCfg.Url,
 		e.TfRepoCfg.Name,
 		e.TfRepoCfg.Name,
 		e.TfRepoCfg.Ref,
 	)}
-	_, err = executeCommand(e.workdir, "/bin/sh", args)
+	_, err := executeCommand(e.workdir, "/bin/sh", args)
 	if err != nil {
-		return errors.New(strings.ReplaceAll(err.Error(), e.glToken, "[REDACTED]"))
+		return err
 	}
 	return nil
-}
-
-func (e *Executor) getAuthUrl(u string) (string, error) {
-	parsedUrl, err := url.Parse(u)
-	if err != nil {
-		return "", err
-	}
-	return fmt.Sprintf("%s://%s:%s@%s%s.git",
-		parsedUrl.Scheme,
-		e.glUsername,
-		e.glToken,
-		parsedUrl.Host,
-		parsedUrl.Path,
-	), nil
 }

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -7,9 +7,8 @@ import (
 	"strings"
 )
 
-// currently supports gitlab repositories
-func (e *Executor) cloneRepo(url, name, ref, dir string) error {
-	authUrl, err := e.getAuthUrl(url)
+func (e *Executor) cloneRepo() error {
+	authUrl, err := e.getAuthUrl(e.TfRepoCfg.Url)
 	if err != nil {
 		return err
 	}
@@ -18,11 +17,11 @@ func (e *Executor) cloneRepo(url, name, ref, dir string) error {
 		// clone repo with specified name and checkout specified ref
 		"git clone %s %s && cd %s && git checkout %s",
 		authUrl,
-		name,
-		name,
-		ref,
+		e.TfRepoCfg.Name,
+		e.TfRepoCfg.Name,
+		e.TfRepoCfg.Ref,
 	)}
-	_, err = executeCommand(dir, "/bin/sh", args)
+	_, err = executeCommand(e.workdir, "/bin/sh", args)
 	if err != nil {
 		return errors.New(strings.ReplaceAll(err.Error(), e.glToken, "[REDACTED]"))
 	}

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -114,26 +114,6 @@ func (e *Executor) generateTfVarsFile(creds TfBackend) error {
 	return nil
 }
 
-func (e *Executor) getModules() error {
-	// create a modules directory within the targetted tf repo directory
-	moduleDir := fmt.Sprintf("%s/%s/%s/remote-modules", e.workdir, e.TfRepoCfg.Name, e.TfRepoCfg.Path)
-	_, err := executeCommand(
-		"/",
-		"mkdir",
-		[]string{"-p", moduleDir},
-	)
-	if err != nil {
-		return err
-	}
-
-	for _, module := range e.TfRepoCfg.Modules {
-		if err = e.cloneRepo(module.Url, module.Name, module.Ref, moduleDir); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // executes target tf plan
 func (e *Executor) processTfPlan() error {
 	dir := fmt.Sprintf("%s/%s/%s", e.workdir, e.TfRepoCfg.Name, e.TfRepoCfg.Path)

--- a/test/config.yaml
+++ b/test/config.yaml
@@ -7,7 +7,3 @@ delete: false
 secret:
   path: terraform/app-sre/prod-network
   version: 4
-modules:
-- name: foo-bar
-  url: https://github.com/app-sre/terraform-repo-modules
-  ref: 364652b72c6386d7515d37abd168cde85b1d1af7


### PR DESCRIPTION
Not necessary if public repositories are enforced for targets. This reduces logic for remote module support (removes need for qr update) and the terraform binary can be leveraged for the operations instead