### PR TITLE
Revert "Add custom ca option for git"

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ An application for performing terraform operations of target git repositories.
 ### Optional
 * `CONFIG_FILE` - defaults to `/config.yaml`
 * `WORKDIR` - defaults to `/tf-repo`
-* `INTERNAL_GIT_CA_PATH` - if using a custom CA for cloning git repos
 
 ## Config file
 The application processes the yaml/json defined at `CONFIG_FILE` for determining targets. The attributes are as follows:

--- a/pkg/git.go
+++ b/pkg/git.go
@@ -2,25 +2,9 @@ package pkg
 
 import (
 	"fmt"
-	"os"
 )
 
 func (e *Executor) cloneRepo() error {
-	// optionally trust internal git server cert
-	caPath := os.Getenv("INTERNAL_GIT_CA_PATH")
-
-	if caPath != "" {
-		args := []string{"-c", fmt.Sprintf(
-			"git config http.sslCAInfo %s",
-			caPath,
-		)}
-
-		_, err := executeCommand(e.workdir, "/bin/sh", args)
-		if err != nil {
-			return err
-		}
-	}
-
 	args := []string{"-c", fmt.Sprintf(
 		// clone repo with specified name and checkout specified ref
 		"git clone %s %s && cd %s && git checkout %s",


### PR DESCRIPTION
Reverts app-sre/terraform-repo-executor#7

Turns out this isn't necessary and breaks anyways. You can just use the `GIT_SSL_CAINFO` env variable to tell Git what path to use.