### PR TITLE
Add support for setting kv engine version to utilize for tf cred retrieval

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An application for performing terraform operations of target git repositories.
 ### Optional
 * `CONFIG_FILE` - defaults to `/config.yaml`
 * `WORKDIR` - defaults to `/tf-repo`
+* `VAULT_TF_KV_VERSION` - defaults to `KV_V2`. Version of vault kv secret engine to expect tf creds within
 
 ## Config file
 The application processes the yaml/json defined at `CONFIG_FILE` for determining targets. The attributes are as follows:

--- a/main.go
+++ b/main.go
@@ -8,11 +8,12 @@ import (
 )
 
 const (
-	CONFIG_FILE     = "CONFIG_FILE"
-	VAULT_ADDR      = "VAULT_ADDR"
-	VAULT_ROLE_ID   = "VAULT_ROLE_ID"
-	VAULT_SECRET_ID = "VAULT_SECRET_ID"
-	WORKDIR         = "WORKDIR"
+	CONFIG_FILE         = "CONFIG_FILE"
+	VAULT_ADDR          = "VAULT_ADDR"
+	VAULT_ROLE_ID       = "VAULT_ROLE_ID"
+	VAULT_SECRET_ID     = "VAULT_SECRET_ID"
+	VAULT_TF_KV_VERSION = "VAULT_TF_KV_VERSION"
+	WORKDIR             = "WORKDIR"
 )
 
 func main() {
@@ -21,12 +22,14 @@ func main() {
 	vaultAddr := getEnvOrError(VAULT_ADDR)
 	roleId := getEnvOrError(VAULT_ROLE_ID)
 	secretId := getEnvOrError(VAULT_SECRET_ID)
+	kvVersion := getEnvOrDefault(VAULT_TF_KV_VERSION, pkg.KV_V2)
 
 	err := pkg.Run(cfgPath,
 		workdir,
 		vaultAddr,
 		roleId,
 		secretId,
+		kvVersion,
 	)
 	if err != nil {
 		log.Fatalln(err)

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -27,18 +27,20 @@ type VaultSecret struct {
 }
 
 type Executor struct {
-	vaultClient   *vault.Client
-	workdir       string
-	vaultAddr     string
-	vaultRoleId   string
-	vaultSecretId string
+	vaultClient      *vault.Client
+	workdir          string
+	vaultAddr        string
+	vaultRoleId      string
+	vaultSecretId    string
+	vaultTfKvVersion string
 }
 
 func Run(cfgPath,
 	workdir,
 	vaultAddr,
 	roleId,
-	secretId string) error {
+	secretId,
+	kvVersion string) error {
 
 	// clear working directory upon exit
 	defer executeCommand("/", "rm", []string{"-rf", workdir})
@@ -60,10 +62,11 @@ func Run(cfgPath,
 
 	// vault creds are stored for later usage when generating tfvars for vault provider
 	e := &Executor{
-		workdir:       workdir,
-		vaultAddr:     vaultAddr,
-		vaultRoleId:   roleId,
-		vaultSecretId: secretId,
+		workdir:          workdir,
+		vaultAddr:        vaultAddr,
+		vaultRoleId:      roleId,
+		vaultSecretId:    secretId,
+		vaultTfKvVersion: kvVersion,
 	}
 
 	errCounter := 0
@@ -94,7 +97,7 @@ func (e *Executor) execute(repo Repo, vaultClient *vault.Client, dryRun bool) er
 		return err
 	}
 
-	backendCreds, err := getVaultTfSecret(vaultClient, repo.Secret)
+	backendCreds, err := getVaultTfSecret(vaultClient, repo.Secret, e.vaultTfKvVersion)
 	if err != nil {
 		return err
 	}

--- a/pkg/vault.go
+++ b/pkg/vault.go
@@ -7,6 +7,11 @@ import (
 	vault "github.com/hashicorp/vault/api"
 )
 
+const (
+	KV_V1 = "KV_V1"
+	KV_V2 = "KV_V2"
+)
+
 func initVaultClient(addr, roleId, secretId string) (*vault.Client, error) {
 	cfg := &vault.Config{
 		Address: addr,
@@ -42,54 +47,71 @@ const (
 	AWS_BUCKET            = "bucket"
 )
 
-// expects appSRE standardized terraform secret keys to exist
-// returns creds specific to account specified in repo target to support aws backend/provider
-// NOTE: this logic is specific to a KV V2 secret engine
-func getVaultTfSecret(client *vault.Client, secretInfo VaultSecret) (TfCreds, error) {
-	// api calls to vault kv v2 secret engines expect 'data' path between root (secret engine name)
-	// and remaining path
-	sliced := strings.SplitN(secretInfo.Path, "/", 2)
-	if len(sliced) < 2 {
-		return TfCreds{}, fmt.Errorf("Invalid vault path: %s", secretInfo.Path)
-	}
-	formattedPath := fmt.Sprintf("%s/data/%s", sliced[0], sliced[1])
+type VaultKvData map[string]interface{}
 
-	var rawSecret *vault.Secret
-	var err error
-	// version is optional in config yaml
-	// default behavior when omitted will be to use latest
-	if secretInfo.Version != 0 {
-		rawSecret, err = client.Logical().ReadWithData(formattedPath, map[string][]string{
-			"version": {fmt.Sprintf("%d", secretInfo.Version)},
-		})
-	} else {
-		rawSecret, err = client.Logical().Read(formattedPath)
-	}
+// returns secret data from a vault kv v1 or v2 secret engine path
+func getVaultTfSecret(client *vault.Client, secretInfo VaultSecret, kvVersion string) (TfCreds, error) {
+	var secret VaultKvData
 
-	if err != nil {
-		return TfCreds{}, err
-	}
-	if rawSecret == nil {
-		return TfCreds{}, fmt.Errorf("No secret found at specified path: %s", secretInfo.Path)
-	}
-	if len(rawSecret.Data) == 0 {
-		return TfCreds{}, fmt.Errorf("No key-values stored within secret at path: %s", secretInfo.Path)
-	}
-	mappedSecret, ok := rawSecret.Data["data"].(map[string]interface{})
-	if !ok {
-		return TfCreds{}, fmt.Errorf("Failed to process data for secret at path: %s", secretInfo.Path)
+	switch kvVersion {
+	case KV_V1:
+		rawSecret, err := client.Logical().Read(secretInfo.Path)
+		if err != nil {
+			return TfCreds{}, err
+		}
+		if rawSecret == nil {
+			return TfCreds{}, fmt.Errorf("No secret found at specified path: %s", secretInfo.Path)
+		}
+		if len(rawSecret.Data) == 0 {
+			return TfCreds{}, fmt.Errorf("No key-values stored within secret at path: %s", secretInfo.Path)
+		}
+		secret = rawSecret.Data
+	case KV_V2:
+		// api calls to vault kv v2 secret engines expect 'data' path between root (secret engine name)
+		// and remaining path
+		sliced := strings.SplitN(secretInfo.Path, "/", 2)
+		if len(sliced) < 2 {
+			return TfCreds{}, fmt.Errorf("Invalid vault path: %s", secretInfo.Path)
+		}
+		path := fmt.Sprintf("%s/data/%s", sliced[0], sliced[1])
+		// version is optional in config yaml
+		// default behavior when omitted will be to use latest
+		var rawSecret *vault.Secret
+		var err error
+		if secretInfo.Version != 0 {
+			rawSecret, err = client.Logical().ReadWithData(path, map[string][]string{
+				"version": {fmt.Sprintf("%d", secretInfo.Version)},
+			})
+		} else {
+			rawSecret, err = client.Logical().Read(path)
+		}
+		if err != nil {
+			return TfCreds{}, err
+		}
+		if rawSecret == nil {
+			return TfCreds{}, fmt.Errorf("No secret found at specified path: %s", secretInfo.Path)
+		}
+		if len(rawSecret.Data) == 0 {
+			return TfCreds{}, fmt.Errorf("No key-values stored within secret at path: %s", secretInfo.Path)
+		}
+		var ok bool
+		secret, ok = rawSecret.Data["data"].(map[string]interface{})
+		if !ok {
+			return TfCreds{}, fmt.Errorf("Failed to process data for secret at path: %s", secretInfo.Path)
+		}
+	default:
+		return TfCreds{}, fmt.Errorf("Invalid vault kv engine version specified: %s", kvVersion)
 	}
 
 	for _, key := range []string{AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_BUCKET, AWS_REGION} {
-		if mappedSecret[key] == nil {
+		if secret[key] == nil {
 			return TfCreds{}, fmt.Errorf("Failed to retrieve %s for secret at path: %s", key, secretInfo.Path)
 		}
 	}
-
 	return TfCreds{
-		AccessKey: mappedSecret[AWS_ACCESS_KEY_ID].(string),
-		SecretKey: mappedSecret[AWS_SECRET_ACCESS_KEY].(string),
-		Bucket:    mappedSecret[AWS_BUCKET].(string),
-		Region:    mappedSecret[AWS_REGION].(string),
+		AccessKey: secret[AWS_ACCESS_KEY_ID].(string),
+		SecretKey: secret[AWS_SECRET_ACCESS_KEY].(string),
+		Bucket:    secret[AWS_BUCKET].(string),
+		Region:    secret[AWS_REGION].(string),
 	}, nil
 }

--- a/pkg/vault_test.go
+++ b/pkg/vault_test.go
@@ -29,7 +29,7 @@ func TestInitVaultClient(t *testing.T) {
 	assert.Equal(t, mockedToken, client.Token())
 }
 
-func TestGetVaultTfSecret(t *testing.T) {
+func TestGetVaultTfSecretV2(t *testing.T) {
 	mockedData := `{
 		"data": {
 			"data": {
@@ -55,7 +55,42 @@ func TestGetVaultTfSecret(t *testing.T) {
 	actual, err := getVaultTfSecret(client, VaultSecret{
 		Path:    "terraform/stage",
 		Version: 3,
+	}, KV_V2)
+	assert.Nil(t, err)
+
+	expected := TfCreds{
+		AccessKey: "foo",
+		SecretKey: "bar",
+		Region:    "weast",
+		Bucket:    "head",
+	}
+
+	assert.Equal(t, expected, actual)
+}
+
+func TestGetVaultTfSecretV1(t *testing.T) {
+	mockedData := `{
+		"data": {
+		  	"aws_access_key_id": "foo",
+			"aws_secret_access_key": "bar",
+			"region": "weast",
+			"bucket": "head"
+		}
+}`
+	vaultMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.URL.Path, "v1/terraform/stage")
+		fmt.Fprint(w, mockedData)
+	}))
+	defer vaultMock.Close()
+
+	client, _ := vault.NewClient(&vault.Config{
+		Address: vaultMock.URL,
 	})
+
+	actual, err := getVaultTfSecret(client, VaultSecret{
+		Path:    "terraform/stage",
+		Version: 1,
+	}, KV_V1)
 	assert.Nil(t, err)
 
 	expected := TfCreds{


### PR DESCRIPTION
Initial version of vault logic only accounted for vault config in prelim environment (where kv v2 was utilized). To accommodate future migrations, the retrieval of vault secrets needs to be more flexible and allow for v1/v2 to be selected.

See https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#read-secret-version and https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v1#read-secret for comparison of returned data format between the two engine versions