### PR TITLE
terraform-state-1.yml support for Terraform Repo Executor

### DIFF
--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -25,6 +25,9 @@ repos:
   secret:
     path: terraform/creds/prod-acount
     version: 4
+  bucket: app-sre
+  region: us-east-1
+  bucket_path: tf-repo
 `
 		cfgPath := fmt.Sprintf("%s/%s", working, "good.yml")
 		os.WriteFile(cfgPath, []byte(raw), 0644)
@@ -46,6 +49,9 @@ repos:
 						Path:    "terraform/creds/prod-acount",
 						Version: 4,
 					},
+					Bucket:     "app-sre",
+					BucketPath: "tf-repo",
+					Region:     "us-east-1",
 				},
 			},
 		}
@@ -76,7 +82,10 @@ repos:
 				"secret": {
 				  "path": "terraform/creds/stage-account",
 				  "version": 1
-				}
+				},
+				"bucket": "app-sre",
+				"bucket_path": "tf-repo",
+				"region": "us-east-1"
 			  }
 			]
 }`
@@ -100,6 +109,9 @@ repos:
 						Path:    "terraform/creds/prod-acount",
 						Version: 4,
 					},
+					Bucket:     "",
+					BucketPath: "",
+					Region:     "",
 				},
 				{
 					Url:    "https://gitlab.myinstance.com/another-gl-group/project_b",
@@ -111,6 +123,9 @@ repos:
 						Path:    "terraform/creds/stage-account",
 						Version: 1,
 					},
+					Bucket:     "app-sre",
+					BucketPath: "tf-repo",
+					Region:     "us-east-1",
 				},
 			},
 		}

--- a/pkg/utils_test.go
+++ b/pkg/utils_test.go
@@ -71,7 +71,10 @@ repos:
 				"secret": {
 				  "path": "terraform/creds/prod-acount",
 				  "version": 4
-				}
+				},
+				"bucket": null,
+				"bucket_path": null,
+				"region": null
 			  },
 			  {
 				"repository": "https://gitlab.myinstance.com/another-gl-group/project_b",


### PR DESCRIPTION
Updates the terraform-repo executor to support the new output from the QR integration in this MR: https://github.com/app-sre/qontract-reconcile/pull/3777

Example of expected output from terraform-repo QR integration now:
```yaml
dry_run: true
repos:
- repository: https://git-example/tf-repo-example
  name: a_repo
  ref: a390f5cb20322c90861d6d80e9b70c6a579be1d0
  project_path: tf
  delete: false
  secret:
    path: aws-secrets/terraform/foo
    version: 1
  bucket: app-sre
  region: us-east-1
  bucket_path: tf-repo
```

This is then processed by the executor to save Terraform statefiles to the expected AWS bucket and in the specified path. Backwards compatibility is maintained with the previous behavior where hardcoded paths were used.