### PR TITLE
Fixes to saving TF outputs to Vault

### DIFF
--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -149,8 +149,8 @@ func (e *Executor) execute(repo Repo, vaultClient *vault.Client, dryRun bool) er
 		return err
 	}
 
-	if len(output) > 0 && repo.TfVariables.Outputs.Path != "" {
-		err = vaultutil.WriteOutputs(vaultClient, repo.TfVariables.Outputs, output)
+	if output != nil && repo.TfVariables.Outputs.Path != "" {
+		err = vaultutil.WriteOutputs(vaultClient, repo.TfVariables.Outputs, output, e.vaultTfKvVersion)
 		if err != nil {
 			return err
 		}

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -218,6 +218,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 	tf.SetStderr(&stderr)
 
 	planFile := fmt.Sprintf("%s/%s-plan", e.workdir, repo.Name)
+	var output map[string]tfexec.OutputMeta
 
 	if dryRun {
 		log.Printf("Performing terraform plan for %s", repo.Name)
@@ -241,13 +242,9 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 
 			if repo.TfVariables.Outputs.Path != "" {
 				log.Printf("Capturing Output values to save to %s in Vault", repo.TfVariables.Outputs.Path)
-				output, err := tf.Output(
+				output, err = tf.Output(
 					context.Background(),
 				)
-				if err != nil {
-					return nil, err
-				}
-				return output, nil
 			}
 		}
 
@@ -260,11 +257,11 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 	log.Println(stdout.String())
 
 	if repo.RequireFips && dryRun {
-		err := e.fipsComplianceCheck(repo, planFile, tf)
+		err = e.fipsComplianceCheck(repo, planFile, tf)
 		if err != nil {
 			return nil, err
 		}
 	}
 
-	return nil, nil
+	return output, nil
 }

--- a/pkg/vaultutil/vaultutil.go
+++ b/pkg/vaultutil/vaultutil.go
@@ -2,8 +2,10 @@
 package vaultutil
 
 import (
+	"context"
 	"fmt"
 	"log"
+	"strconv"
 	"strings"
 
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -54,24 +56,63 @@ func InitVaultClient(addr, roleID, secretID string) (*vault.Client, error) {
 }
 
 // WriteOutputs takes any output values from a Terraform apply and then writes them into Vault
-func WriteOutputs(client *vault.Client, secretInfo VaultSecret, data map[string]tfexec.OutputMeta) error {
+func WriteOutputs(client *vault.Client, secretInfo VaultSecret, data map[string]tfexec.OutputMeta, kvVersion string) error {
 	log.Printf("Writing Output values from Terraform Apply to %s in Vault", secretInfo.Path)
-	secretData := make(map[string]interface{})
+	secretData := make(VaultKvData)
 
 	for k, v := range data {
-		secretData[k] = v.Value
+		if v.Value[0] == '"' {
+			// unquote the value as hashicorp seems to like quotes
+			value, err := strconv.Unquote(string(v.Value[:]))
+			if err != nil {
+				return err
+			}
+			secretData[k] = value
+		} else {
+			secretData[k] = string(v.Value[:])
+		}
 	}
 
-	_, err := WriteVaultSecret(client, secretInfo, secretData)
+	err := WriteVaultSecret(client, secretInfo, secretData, kvVersion)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
+// converts a secret path to KvV2 formatting
+// https://developer.hashicorp.com/vault/api-docs/secret/kv/kv-v2#create-update-secret
+// api calls to vault kv v2 secret engines expect 'data' path between root (secret engine name)
+// and remaining path
+func convertPathKvV2(path string) (string, error) {
+	sliced := strings.SplitN(path, "/", 2)
+	if len(sliced) < 2 {
+		return "", fmt.Errorf("invalid vault path: %s", path)
+	}
+	return fmt.Sprintf("%s/data/%s", sliced[0], sliced[1]), nil
+}
+
+// splits the path into the mount (1st return) and secret path (2nd return)
+func splitVaultPath(path string) (string, string, error) {
+	before, after, found := strings.Cut(path, "/")
+
+	if !found {
+		return "", "", fmt.Errorf("invalid vault path: %s", path)
+	}
+	return before, after, nil
+}
+
 // WriteVaultSecret writes a map of KV pairs to Vault at the specified path
-func WriteVaultSecret(client *vault.Client, secretInfo VaultSecret, data map[string]interface{}) (*vault.Secret, error) {
-	return client.Logical().Write(secretInfo.Path, data)
+func WriteVaultSecret(client *vault.Client, secretInfo VaultSecret, data map[string]interface{}, kvVersion string) error {
+	mount, path, err := splitVaultPath(secretInfo.Path)
+	if err != nil {
+		return err
+	}
+	if kvVersion == KvV2 {
+		_, err = client.KVv2(mount).Put(context.Background(), path, data)
+		return err
+	}
+	return client.KVv1(mount).Put(context.Background(), path, data)
 }
 
 // GetVaultTfSecret retrieves the contents of a secret in Vault
@@ -92,17 +133,13 @@ func GetVaultTfSecret(client *vault.Client, secretInfo VaultSecret, kvVersion st
 		}
 		secret = rawSecret.Data
 	case KvV2:
-		// api calls to vault kv v2 secret engines expect 'data' path between root (secret engine name)
-		// and remaining path
-		sliced := strings.SplitN(secretInfo.Path, "/", 2)
-		if len(sliced) < 2 {
-			return nil, fmt.Errorf("invalid vault path: %s", secretInfo.Path)
+		path, err := convertPathKvV2(secretInfo.Path)
+		if err != nil {
+			return nil, err
 		}
-		path := fmt.Sprintf("%s/data/%s", sliced[0], sliced[1])
 		// version is optional in config yaml
 		// default behavior when omitted will be to use latest
 		var rawSecret *vault.Secret
-		var err error
 		if secretInfo.Version != 0 {
 			rawSecret, err = client.Logical().ReadWithData(path, map[string][]string{
 				"version": {fmt.Sprintf("%d", secretInfo.Version)},

--- a/pkg/vaultutil/vaultutil.go
+++ b/pkg/vaultutil/vaultutil.go
@@ -61,12 +61,18 @@ func WriteOutputs(client *vault.Client, secretInfo VaultSecret, data map[string]
 	secretData := make(VaultKvData)
 
 	for k, v := range data {
+		// Each value included in OutputMeta is of type json.RawMessage or in other words, a raw JSON string.
+		// When tfexec is decoding the stdout of `terraform output`, it does not remove those double quotes
+		// since a valid string in JSON includes quotes around. Therefore we try and remove those ourselves
+		// when saving a stringified version of the JSON value to Vault
 		if v.Value[0] == '"' {
 			value, err := strconv.Unquote(string(v.Value[:]))
 			if err != nil {
-				return err
+				log.Printf("Unable to remove extra quotes around key: %s, saving raw output to Vault", k)
+				secretData[k] = string(v.Value[:])
+			} else {
+				secretData[k] = value
 			}
-			secretData[k] = value
 		} else {
 			secretData[k] = string(v.Value[:])
 		}

--- a/pkg/vaultutil/vaultutil.go
+++ b/pkg/vaultutil/vaultutil.go
@@ -62,7 +62,6 @@ func WriteOutputs(client *vault.Client, secretInfo VaultSecret, data map[string]
 
 	for k, v := range data {
 		if v.Value[0] == '"' {
-			// unquote the value as hashicorp seems to like quotes
 			value, err := strconv.Unquote(string(v.Value[:]))
 			if err != nil {
 				return err

--- a/pkg/vaultutil/vaultutil_test.go
+++ b/pkg/vaultutil/vaultutil_test.go
@@ -108,8 +108,7 @@ func TestGetVaultTfSecretV1(t *testing.T) {
 
 func TestWriteVaultOutputs(t *testing.T) {
 	type payload struct {
-		VPCID               string `json:"vpc_id"`
-		UnquotedSensitiveID string `json:"unquoted_sensitive_id"`
+		VPCID string `json:"vpc_id"`
 	}
 
 	type data struct {
@@ -122,17 +121,11 @@ func TestWriteVaultOutputs(t *testing.T) {
 			Type:      json.RawMessage(`string`),
 			Value:     json.RawMessage(`"vpc-22fd8eb8"`),
 		},
-		"unquoted_sensitive_id": {
-			Sensitive: true,
-			Type:      json.RawMessage(`string`),
-			Value:     json.RawMessage(`massivesecret`),
-		},
 	}
 
 	vaultMock := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := payload{
-			VPCID:               "vpc-22fd8eb8",
-			UnquotedSensitiveID: "massivesecret",
+			VPCID: "vpc-22fd8eb8",
 		}
 
 		assert.Contains(t, r.URL.Path, "stage/outputs")


### PR DESCRIPTION
[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)

Code fixes for changes introduced in #17. These were tested using a local minikube/localstack environment documented at https://gitlab.cee.redhat.com/app-sre/terraform-repo-tekton

- Squash a few bugs discovered in the process
- Update vault write function to use the Vault KV API rather than logical as I was running into issues with writing and KV2 pathing
- vaultutil.go refactoring
- Add a unit test to verify outputs are properly converted to a format that the Vault API expects