### PR TITLE
Do not log terraform output

### DIFF
--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -213,7 +213,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 		return nil, err
 	}
 
-	var stdout, stderr bytes.Buffer
+	var stdout, stderr, blackhole bytes.Buffer
 	tf.SetStdout(&stdout)
 	tf.SetStderr(&stderr)
 
@@ -242,6 +242,9 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 
 			if repo.TfVariables.Outputs.Path != "" {
 				log.Printf("Capturing Output values to save to %s in Vault", repo.TfVariables.Outputs.Path)
+				// don't log the results of `terraform output -json` as that can leak sensitive credentials
+				tf.SetStdout(&blackhole)
+				tf.SetStderr(&blackhole)
 				output, err = tf.Output(
 					context.Background(),
 				)


### PR DESCRIPTION
[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)

`terraform output -json` logs sensitive values in plaintext as [their docs note](https://developer.hashicorp.com/terraform/cli/commands/output). This change updates the behavior so that the output for those commands is sent to a buffer that is not printed during execution. 