### PR TITLE
Remove hardcoded KV mount version

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,34 @@ Terraform Repo executor takes input from a corresponding [Qontract Reconcile int
 * **Optional**
   * `CONFIG_FILE` - input/config file location, defaults to `/config.yaml`
   * `WORKDIR` - working directory for tf operations, defaults to `/tf-repo`
-  * `VAULT_TF_KV_VERSION` - defaults to `KV_V2`. Specifies which version of the [Vault `kv` secrets engine to use for reading/writing secrets](https://developer.hashicorp.com/vault/docs/secrets/kv)
   * `GIT_SSL_CAINFO` - allows you to supply [custom certificate authorities when dealing with self-signed gitlab instances](https://git-scm.com/docs/git-config#Documentation/git-config.txt-httpsslCAInfo), in this case this is the path to the certs
+
+## AppRole Permissions
+
+Configuring the AppRole for Terraform Repo should be done within App Interface. Here is an example of the kind of permissions that Terraform Repo will need (using KVv2 format):
+
+```hcl
+# Replace this path with wherever your AWS account credentials are stored, Terraform Repo needs this access to
+# read/write to AWS
+path "aws-accounts/data/terraform/*" {
+  capabilities = ["read"]
+}
+
+# tenants will place their secrets into folders labeled under their team names in the
+# input and output directory
+path "terraform-repo/data/input/*" {
+  capabilities = ["read"]
+}
+
+path "terraform-repo/data/output/*" {
+  capabilities = ["create", "update", "read", "delete"]
+}
+
+# required for getting information about if a mount is KVv1 or V2 for read/write operations
+path "sys/mounts" {
+  capabilities = ["read", "list"]
+}
+```
 
 ## Config file
 

--- a/main.go
+++ b/main.go
@@ -6,21 +6,19 @@ import (
 	"os"
 
 	"github.com/app-sre/terraform-repo-executor/pkg"
-	"github.com/app-sre/terraform-repo-executor/pkg/vaultutil"
 )
 
 // environment variables
 const (
-	ConfigFile       = "CONFIG_FILE"
-	VaultAddr        = "VAULT_ADDR"
-	VaultRoleID      = "VAULT_ROLE_ID"
-	VaultSecretID    = "VAULT_SECRET_ID"
-	VaultTfKvVersion = "VAULT_TF_KV_VERSION"
-	WorkDir          = "WORKDIR"
-	GitlabLogRepo    = "GITLAB_LOG_REPO"
-	GitlabUsername   = "GITLAB_USERNAME"
-	GitlabToken      = "GITLAB_TOKEN"
-	GitEmail         = "GIT_EMAIL"
+	ConfigFile     = "CONFIG_FILE"
+	VaultAddr      = "VAULT_ADDR"
+	VaultRoleID    = "VAULT_ROLE_ID"
+	VaultSecretID  = "VAULT_SECRET_ID"
+	WorkDir        = "WORKDIR"
+	GitlabLogRepo  = "GITLAB_LOG_REPO"
+	GitlabUsername = "GITLAB_USERNAME"
+	GitlabToken    = "GITLAB_TOKEN"
+	GitEmail       = "GIT_EMAIL"
 )
 
 func main() {
@@ -29,7 +27,6 @@ func main() {
 	vaultAddr := getEnvOrError(VaultAddr)
 	roleID := getEnvOrError(VaultRoleID)
 	secretID := getEnvOrError(VaultSecretID)
-	kvVersion := getEnvOrDefault(VaultTfKvVersion, vaultutil.KvV2)
 	gitlabLogRepo := getEnvOrError(GitlabLogRepo)
 	gitlabUsername := getEnvOrError(GitlabUsername)
 	gitlabToken := getEnvOrError(GitlabToken)
@@ -40,7 +37,6 @@ func main() {
 		vaultAddr,
 		roleID,
 		secretID,
-		kvVersion,
 		gitlabLogRepo,
 		gitlabUsername,
 		gitlabToken,

--- a/pkg/vaultutil/vaultutil_test.go
+++ b/pkg/vaultutil/vaultutil_test.go
@@ -33,6 +33,10 @@ func TestInitVaultClient(t *testing.T) {
 }
 
 func TestGetVaultTfSecretV2(t *testing.T) {
+	mountData := map[string]string{
+		"terraform": KvV2,
+	}
+
 	mockedData := `{
 		"data": {
 			"data": {
@@ -58,7 +62,7 @@ func TestGetVaultTfSecretV2(t *testing.T) {
 	actual, err := GetVaultTfSecret(client, VaultSecret{
 		Path:    "terraform/stage",
 		Version: 3,
-	}, KvV2)
+	}, mountData)
 	assert.Nil(t, err)
 
 	expected := VaultKvData{
@@ -72,6 +76,10 @@ func TestGetVaultTfSecretV2(t *testing.T) {
 }
 
 func TestGetVaultTfSecretV1(t *testing.T) {
+	mountData := map[string]string{
+		"terraform": KvV1,
+	}
+
 	mockedData := `{
 		"data": {
 		  	"aws_access_key_id": "foo",
@@ -93,7 +101,7 @@ func TestGetVaultTfSecretV1(t *testing.T) {
 	actual, err := GetVaultTfSecret(client, VaultSecret{
 		Path:    "terraform/stage",
 		Version: 1,
-	}, KvV1)
+	}, mountData)
 	assert.Nil(t, err)
 
 	expected := VaultKvData{
@@ -159,15 +167,23 @@ func TestWriteVaultOutputs(t *testing.T) {
 		Address: vaultMock.URL,
 	})
 
+	mountData := map[string]string{
+		"terraform": KvV1,
+	}
+
 	err := WriteOutputs(client, VaultSecret{
 		Path: "terraform/stage/outputs",
-	}, planOutput, KvV1)
+	}, planOutput, mountData)
 
 	assert.Nil(t, err)
 
+	mountData = map[string]string{
+		"terraform": KvV2,
+	}
+
 	err = WriteOutputs(client, VaultSecret{
 		Path: "terraform/stage/outputs",
-	}, planOutput, KvV2)
+	}, planOutput, mountData)
 
 	assert.Nil(t, err)
 }


### PR DESCRIPTION
Remove the `VAULT_TF_KV_VERSION` environment variable and instead rely on a quick function that queries Vault for the KV version of each mounted secret engine. A map of engine names to versions is then used to determine which function to use.

In FedRamp we use KVv2 engines across the board however commercial uses some KVv1 engines so this makes the executor more flexible across different repos.

[APPSRE-8705](https://issues.redhat.com/browse/APPSRE-8705)