### PR TITLE
Remove undeclared variable warnings from printed output

### DIFF
--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -276,7 +276,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 	}
 
 	log.Printf("Output for %s\n", repo.Name)
-	log.Println(stdout.String())
+	log.Println(RemoveUndeclaredWarnings(stdout.String()))
 
 	if repo.RequireFips && dryRun {
 		err = e.fipsComplianceCheck(repo, planFile, tf)

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -97,3 +97,12 @@ func MaskSensitiveStateValues(src string) string {
 	re := regexp.MustCompile(`(?sU)(data "vault_.+\n})`)
 	return re.ReplaceAllString(src, "[REDACTED VAULT SECRET]")
 }
+
+// RemoveUndeclaredWarnings takes in Terraform plan outputs and removes any warnings about undeclared variables
+// which happen due to partial backend initialization
+// tf doesn't give you an option to remove these warnings https://github.com/hashicorp/terraform/issues/22004
+// and we cannot use compact warnings due to limitations in the tfexec library so this is the next best option
+func RemoveUndeclaredWarnings(src string) string {
+	re := regexp.MustCompile(`Warning:.+undeclared variable.?\n+(?s).+(option|declared)\.`)
+	return re.ReplaceAllString(src, "")
+}


### PR DESCRIPTION
Terraform Repo makes use of `.tfvars` files to do partial backend initialization, see https://github.com/app-sre/terraform-repo-executor/blob/main/pkg/terraform.go#L107. This partial backend init includes Vault credentials however with the new secret approach in tf-repo M1, most repos will not be defining `vault_addr`, `vault_role_id`, and `vault_secret_id` in their .tf files.

Therefore, when a plan happens you see warnings like these:
```
....
Plan: 1 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + vpc_id = (sensitive value)

Warning: Value for undeclared variable

The root module does not declare a variable named "vault_addr" but a value
was found in file "aws.auto.tfvars". If you meant to use this value, add a
"variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Value for undeclared variable

The root module does not declare a variable named "vault_role_id" but a value
was found in file "aws.auto.tfvars". If you meant to use this value, add a
"variable" block to the configuration.

To silence these warnings, use TF_VAR_... environment variables to provide
certain "global" settings to all configurations in your organization. To
reduce the verbosity of these warnings, use the -compact-warnings option.

Warning: Values for undeclared variables

In addition to the other similar warnings shown, 1 other variable(s) defined
without being declared.
```

We can't use compact-warnings due to limitations in tfexec, and Terraform itself doesn't offer a way to disable these warnings so I'm just removing them with regex from the final output since they may confuse users.