### PR TITLE
Terraform Repo update to support terraform_remote_state datasources

### DIFF
--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -145,7 +145,7 @@ func combineEnvVariables(creds TfCreds) map[string]string {
 		split := strings.Split(env, "=")
 		// ignore any TF_ prefixed variables as tfexec will error
 		// https://github.com/hashicorp/terraform-exec/blob/main/tfexec/cmd.go#L22-L39
-		if len(split) > 1 && strings.HasPrefix(split[0], "TF_") {
+		if len(split) > 1 && !strings.HasPrefix(split[0], "TF_") {
 			ret[split[0]] = split[1]
 		}
 	}

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -201,7 +201,7 @@ func (e *Executor) showRaw(dir string, tfBinaryLocation string) (string, error) 
 
 // performs a terraform plan and then apply if not running in dry run mode
 // additionally captures any tf outputs if necessary
-func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.OutputMeta, error) {
+func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]string) (map[string]tfexec.OutputMeta, error) {
 	dir := fmt.Sprintf("%s/%s/%s", e.workdir, repo.Name, repo.Path)
 
 	// each repo can use a different version of the TF binary, specified in App Interface
@@ -224,6 +224,11 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool) (map[string]tfexec.Outp
 	var stdout, stderr, blackhole bytes.Buffer
 	tf.SetStdout(&stdout)
 	tf.SetStderr(&stderr)
+	// supply aws access key, secret key variables to the terraform executable for remote_backend_state
+	err = tf.SetEnv(envVars)
+	if err != nil {
+		return nil, err
+	}
 
 	planFile := fmt.Sprintf("%s/%s-plan", e.workdir, repo.Name)
 	var output map[string]tfexec.OutputMeta


### PR DESCRIPTION
I hit a snag with migrating Terraform repos in commercial infra. There are a few repos that use [terraform-remote-state-data](https://developer.hashicorp.com/terraform/language/state/remote-state-data) with the S3 backend. However, the standard tf-repo way to supply AWS creds:

```tf
provider "aws" {
  region = "us-east-1"
  access_key = var.access_key
  secret_key = var.secret_key
```

Does not make those credentials available to a `terraform_remote_state` datasource using the S3 backend. This update provides AWS credentials in the form of environment variables to the Terraform executable. Tested with my localstack config.

[APPSRE-10986](https://issues.redhat.com/browse/APPSRE-10986)