### PR TITLE
:page_facing_up: add license file to image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN ${TFENV_BIN} tf install 1.4.5 && \
 FROM registry.access.redhat.com/ubi9-minimal:9.5-1731604394 AS prod
 COPY --from=builder /build/terraform-repo-executor  /usr/bin/terraform-repo-executor
 COPY --from=downloader /usr/bin/Terraform /usr/bin/Terraform
+COPY LICENSE /licenses/LICENSE
 COPY entrypoint.sh /usr/bin
 
 RUN microdnf update -y && \


### PR DESCRIPTION
The enterprise contract enforces a license file in all Konflux images.

```
        "failed": [
            {
                "name": "HasLicense",
                "elapsed_time": 0,
                "description": "Checking if terms and conditions applicable to the software including open source licensing information are present. The license must be at /licenses",
                "help": "Check HasLicense encountered an error. Please review the preflight.log file for more information.",
                "suggestion": "Create a directory named /licenses and include all relevant licensing and/or terms and conditions as text file(s) in that directory.",
                "knowledgebase_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction",
                "check_url": "https://access.redhat.com/documentation/en-us/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#assembly-requirements-for-container-images_openshift-sw-cert-policy-introduction"
            }
        ]
```