### PR TITLE
Log to stdout while terraform operations are in progress

### DIFF
--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"bytes"
 	"context"
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -221,9 +220,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 		return nil, err
 	}
 
-	var stdout, stderr, blackhole bytes.Buffer
-	tf.SetStdout(&stdout)
-	tf.SetStderr(&stderr)
+	var blackhole bytes.Buffer
 	// supply aws access key, secret key variables to the terraform executable for remote_backend_state
 	err = tf.SetEnv(envVars)
 	if err != nil {
@@ -266,7 +263,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 
 	}
 	if err != nil {
-		return nil, errors.New(stderr.String())
+		return nil, err
 	}
 
 	if !dryRun {
@@ -279,9 +276,6 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 			log.Printf("Unable to commit state file to Git, error: %s", err)
 		}
 	}
-
-	log.Printf("Output for %s\n", repo.Name)
-	log.Println(RemoveUndeclaredWarnings(stdout.String()))
 
 	if repo.RequireFips && dryRun {
 		err = e.fipsComplianceCheck(repo, planFile, tf)

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"text/template"
+	"time"
 
 	"github.com/app-sre/terraform-repo-executor/pkg/vaultutil"
 	"github.com/hashicorp/terraform-exec/tfexec"
@@ -199,6 +200,22 @@ func (e *Executor) showRaw(dir string, tfBinaryLocation string) (string, error) 
 	return out, err
 }
 
+// our jenkins instances are set to time out after 30 minutes of no logs to the console so this simply
+// prints out a log message once a minute that the apply/plan/destroy is still in progress so pipelines don't time out
+func reportProgress(done <-chan bool, repoName string) {
+	ticker := time.NewTicker(1 * time.Minute)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-done:
+			log.Printf("Terraform action completed for %s", repoName)
+			return
+		case <-ticker.C:
+			log.Printf("Terraform action is still running for %s...", repoName)
+		}
+	}
+}
+
 // performs a terraform plan and then apply if not running in dry run mode
 // additionally captures any tf outputs if necessary
 func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]string) (map[string]tfexec.OutputMeta, error) {
@@ -233,8 +250,11 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 	planFile := fmt.Sprintf("%s/%s-plan", e.workdir, repo.Name)
 	var output map[string]tfexec.OutputMeta
 
+	done := make(chan bool)
+
 	if dryRun {
 		log.Printf("Performing terraform plan for %s", repo.Name)
+		go reportProgress(done, repo.Name)
 		_, err = tf.Plan(
 			context.Background(),
 			tfexec.Destroy(repo.Delete),
@@ -244,11 +264,13 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 		// tf.exec.Destroy flag cannot be passed to tf.Apply in same fashion as above Plan() logic
 		if repo.Delete {
 			log.Printf("Performing terraform destroy for %s", repo.Name)
+			go reportProgress(done, repo.Name)
 			err = tf.Destroy(
 				context.Background(),
 			)
 		} else {
 			log.Printf("Performing terraform apply for %s", repo.Name)
+			go reportProgress(done, repo.Name)
 			err = tf.Apply(
 				context.Background(),
 			)
@@ -265,6 +287,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 		}
 
 	}
+	close(done)
 	if err != nil {
 		return nil, errors.New(stderr.String())
 	}

--- a/pkg/utils.go
+++ b/pkg/utils.go
@@ -81,12 +81,3 @@ func MaskSensitiveStateValues(src string) string {
 	re := regexp.MustCompile(`(?sU)(data "vault_.+\n})`)
 	return re.ReplaceAllString(src, "[REDACTED VAULT SECRET]")
 }
-
-// RemoveUndeclaredWarnings takes in Terraform plan outputs and removes any warnings about undeclared variables
-// which happen due to partial backend initialization
-// tf doesn't give you an option to remove these warnings https://github.com/hashicorp/terraform/issues/22004
-// and we cannot use compact warnings due to limitations in the tfexec library so this is the next best option
-func RemoveUndeclaredWarnings(src string) string {
-	re := regexp.MustCompile(`Warning:.+undeclared variable.?\n+(?s).+(option|declared)\.`)
-	return re.ReplaceAllString(src, "")
-}


### PR DESCRIPTION
[APPSRE-12041](https://issues.redhat.com/browse/APPSRE-12041)

Updates tf-repo behavior to log to stdout/stderr when a terraform plan/apply/destroy are in progress. Ensures that long running pipelines aren't aborted due to no log output.