### PR TITLE
feat: Add TF_PARALLELISM env var to control Terraform parallelism

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Terraform Repo executor takes input from a corresponding [Qontract Reconcile int
   * `CONFIG_FILE` - input/config file location, defaults to `/config.yaml`
   * `WORKDIR` - working directory for tf operations, defaults to `/tmp/tf-repo`
   * `USE_CUSTOM_CA` - set to `true` for tf-repo to load custom certs into the container's trust store
+  * `TF_PARALLELISM` - how many [concurrent operations for terraform to run](https://developer.hashicorp.com/terraform/cli/commands/plan#parallelism-n) (defaults to 10)
 
 ## Custom Certificate Authorities
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/app-sre/terraform-repo-executor/pkg"
 )
@@ -19,6 +20,7 @@ const (
 	GitlabUsername = "GITLAB_USERNAME"
 	GitlabToken    = "GITLAB_TOKEN"
 	GitEmail       = "GIT_EMAIL"
+	TfParallelism  = "TF_PARALLELISM"
 )
 
 func main() {
@@ -31,8 +33,15 @@ func main() {
 	gitlabUsername := getEnvOrError(GitlabUsername)
 	gitlabToken := getEnvOrError(GitlabToken)
 	gitEmail := getEnvOrError(GitEmail)
+	tfParallelism := getEnvOrDefault(TfParallelism, "10")
 
-	err := pkg.Run(cfgPath,
+	tfParallelismInt, err := strconv.Atoi(tfParallelism)
+
+	if err != nil {
+		log.Fatal("Integer value required for `TF_PARALLELISM` environment variable")
+	}
+
+	err = pkg.Run(cfgPath,
 		workdir,
 		vaultAddr,
 		roleID,
@@ -41,6 +50,7 @@ func main() {
 		gitlabUsername,
 		gitlabToken,
 		gitEmail,
+		tfParallelismInt,
 	)
 	if err != nil {
 		log.Fatalln(err)

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -56,6 +56,7 @@ type Executor struct {
 	gitlabToken    string
 	gitEmail       string
 	mountVersions  map[string]string
+	tfParallelism  int
 }
 
 // StateVars are used to render the raw statefile in markdown
@@ -79,7 +80,7 @@ func Run(cfgPath,
 	gitlabLogRepo,
 	gitlabUsername,
 	gitlabToken,
-	gitEmail string) error {
+	gitEmail string, tfParallelism int) error {
 
 	cfg, err := processConfig(cfgPath)
 	if err != nil {
@@ -107,6 +108,7 @@ func Run(cfgPath,
 		gitlabToken:    gitlabToken,
 		gitEmail:       gitEmail,
 		mountVersions:  mountVersions,
+		tfParallelism:  tfParallelism,
 	}
 
 	errCounter := 0

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -238,6 +238,7 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 			context.Background(),
 			tfexec.Destroy(repo.Delete),
 			tfexec.Out(planFile), // this plan file will be useful to have in a later improvement as well
+			tfexec.Parallelism(e.tfParallelism),
 		)
 	} else {
 		// tf.exec.Destroy flag cannot be passed to tf.Apply in same fashion as above Plan() logic
@@ -245,11 +246,13 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 			log.Printf("Performing terraform destroy for %s", repo.Name)
 			err = tf.Destroy(
 				context.Background(),
+				tfexec.Parallelism(e.tfParallelism),
 			)
 		} else {
 			log.Printf("Performing terraform apply for %s", repo.Name)
 			err = tf.Apply(
 				context.Background(),
+				tfexec.Parallelism(e.tfParallelism),
 			)
 
 			if repo.TfVariables.Outputs.Path != "" {


### PR DESCRIPTION
Introduces the `TF_PARALLELISM` environment variable, allowing users to configure the number of concurrent operations Terraform runs during plans/applies/destroys. The default value is set to 10.

Aims to address timeout issues in [APPSRE-12041](https://issues.redhat.com/browse/APPSRE-12041)