### PR TITLE
Update to go 1.23.9 + upgrade linting + formatting tool versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 terraform 1.4.5
-golang 1.21.13
+golang 1.23.11

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 terraform 1.4.5
-golang 1.23.11
+golang 1.23.9

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372@sha256:dd69221a8511b10ceabab8d695d2c05d994d595a8fdcffeb8e935b2db807faba AS builder
+FROM  registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751375493@sha256:61346f0fa41198d706d60beae417fb3ff8be34260eeef52d7b1ca0cbf344caae AS builder
 WORKDIR /build
 RUN git config --global --add safe.directory /build
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM  registry.access.redhat.com/ubi9/go-toolset:1.21.13-2.1729776560@sha256:97e30a01caeece72ee967013e7c7af777ea4ee93840681ddcfe38a87eb4c084a AS builder
+FROM  registry.access.redhat.com/ubi9/go-toolset:1.23.9-1751538372@sha256:dd69221a8511b10ceabab8d695d2c05d994d595a8fdcffeb8e935b2db807faba AS builder
 WORKDIR /build
 RUN git config --global --add safe.directory /build
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME				:= terraform-repo-executor
 REPO				:= quay.io/app-sre/$(NAME)
-REVIVE_VERSION		:= v1.3.7
-STATICCHECK_VERSION	:= 2023.1.7
+REVIVE_VERSION		:= v1.11.0
+STATICCHECK_VERSION	:= 2025.1.1
 TAG					:= $(shell git rev-parse --short HEAD)
 
 PKGS				:= $(shell go list ./... | grep -v -E '/vendor/|/test')

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/app-sre/terraform-repo-executor
 
-go 1.21
+go 1.23.11
 
 require (
 	github.com/go-git/go-git/v5 v5.13.2

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/app-sre/terraform-repo-executor
 
-go 1.23.11
+go 1.23.9
 
 require (
 	github.com/go-git/go-git/v5 v5.13.2


### PR DESCRIPTION
Upgrading the version to hopefully fix a lot of the Renovate PRs that are broken in the PR list.

Also bumps the formatting + linting tool versions since these won't be picked up on by Renovate.