### PR TITLE
[bugfix] ensure Terraform Repo `apply` returns an error

### DIFF
--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -240,6 +240,9 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 			tfexec.Out(planFile), // this plan file will be useful to have in a later improvement as well
 			tfexec.Parallelism(e.tfParallelism),
 		)
+		if err != nil {
+			return nil, err
+		}
 	} else {
 		// tf.exec.Destroy flag cannot be passed to tf.Apply in same fashion as above Plan() logic
 		if repo.Delete {

--- a/pkg/vaultutil/vaultutil.go
+++ b/pkg/vaultutil/vaultutil.go
@@ -66,7 +66,7 @@ func InitVaultClient(addr, roleID, secretID string) (*vault.Client, error) {
 		return nil, err
 	}
 	if secret == nil || secret.Auth == nil {
-		return nil, err
+		return nil, fmt.Errorf("authentication failed: no valid auth token received")
 	}
 
 	client.SetToken(secret.Auth.ClientToken)


### PR DESCRIPTION
Fixes a bug in the code where an error in `terraform apply` could not be returned correctly if outputs are specified. Also fixes a couple other instances of not handling the `err` object and adds a more descriptive Vault error.

Assisted with Claude Code