### PR TITLE
Validate that users are using an S3 backend by pulling the statefile

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,6 +46,7 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
+	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	golang.org/x/crypto v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,6 +114,8 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/pkg/terraform_test.go
+++ b/pkg/terraform_test.go
@@ -1,12 +1,15 @@
 package pkg
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"testing"
 
 	"github.com/app-sre/terraform-repo-executor/pkg/vaultutil"
+	"github.com/hashicorp/terraform-exec/tfexec"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 )
 
 const (
@@ -163,5 +166,126 @@ func TestWriteTemplate(t *testing.T) {
 		assert.Nil(t, err)
 
 		assert.Equal(t, string(expected), string(output))
+	})
+}
+
+// MockTerraformExecutor is a testify mock for TerraformExecutor~ interface
+type MockTerraformExecutor struct {
+	mock.Mock
+}
+
+func (m *MockTerraformExecutor) StatePull(ctx context.Context, opts ...tfexec.StatePullOption) (string, error) {
+	args := m.Called(ctx, opts)
+	return args.String(0), args.Error(1)
+}
+
+func TestValidateS3Backend(t *testing.T) {
+	executor := &Executor{}
+	repo := Repo{Name: "test-repo"}
+
+	t.Run("successful S3 backend validation", func(t *testing.T) {
+		validS3State := `{
+			"version": 4,
+			"backend": {
+				"type": "s3",
+				"config": {
+					"bucket": "test-bucket",
+					"key": "terraform.tfstate",
+					"region": "us-east-1"
+				}
+			}
+		}`
+
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return(validS3State, nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Nil(t, err)
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when StatePull returns error", func(t *testing.T) {
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return("", fmt.Errorf("state pull failed"))
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to pull terraform state for repo 'test-repo'")
+		assert.Contains(t, err.Error(), "state pull failed")
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when state is empty", func(t *testing.T) {
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return("", nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "repository 'test-repo' has empty terraform state, which indicates no S3 backend is configured")
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when state is invalid JSON", func(t *testing.T) {
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return("invalid json", nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to parse terraform state for repo 'test-repo'")
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when backend configuration is missing", func(t *testing.T) {
+		stateWithoutBackend := `{
+			"version": 4,
+			"resources": []
+		}`
+
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return(stateWithoutBackend, nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "repository 'test-repo' does not have backend configuration in terraform state")
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when backend type is missing", func(t *testing.T) {
+		stateWithInvalidBackend := `{
+			"version": 4,
+			"backend": {
+				"config": {
+					"bucket": "test-bucket"
+				}
+			}
+		}`
+
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return(stateWithInvalidBackend, nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "repository 'test-repo' has invalid backend type in terraform state")
+		mockTerraform.AssertExpectations(t)
+	})
+
+	t.Run("fails when backend type is not s3", func(t *testing.T) {
+		localBackendState := `{
+			"version": 4,
+			"backend": {
+				"type": "local",
+				"config": {
+					"path": "terraform.tfstate"
+				}
+			}
+		}`
+
+		mockTerraform := new(MockTerraformExecutor)
+		mockTerraform.On("StatePull", mock.Anything, mock.Anything).Return(localBackendState, nil)
+
+		err := executor.validateS3Backend(mockTerraform, repo)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "repository 'test-repo' is using backend type 'local' instead of required S3 backend")
+		mockTerraform.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
Second go-around at https://github.com/app-sre/terraform-repo-executor/pull/83

After some feedback from @hemslo I'm using a simpler method to validate the user has their repo setup. The S3 backend is pulled after `terraform init` is run and checked to make sure that S3 is being used.

[APPSRE-12336](https://issues.redhat.com/browse/APPSRE-12336)