### PR TITLE
Pin to golang 1.24.6 + more reliable logging

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 terraform 1.4.5
-golang 1.25.0
+golang 1.24.6

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,12 +1,7 @@
 #!/bin/bash
 
-# Handle custom CA if needed
 if [[ $USE_CUSTOM_CA == "true" ]]; then
     update-ca-trust
 fi
 
-# Set default log flush delay for Vector logging (can be overridden)
-export LOG_FLUSH_DELAY_SECONDS=${LOG_FLUSH_DELAY_SECONDS:-2}
-
-# Execute main application
 /usr/bin/terraform-repo-executor

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
+
+# Handle custom CA if needed
 if [[ $USE_CUSTOM_CA == "true" ]]; then
     update-ca-trust
 fi
 
+# Set default log flush delay for Vector logging (can be overridden)
+export LOG_FLUSH_DELAY_SECONDS=${LOG_FLUSH_DELAY_SECONDS:-2}
+
+# Execute main application
 /usr/bin/terraform-repo-executor

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/app-sre/terraform-repo-executor
 
-go 1.23.9
+go 1.24.6
 
 require (
 	github.com/go-git/go-git/v5 v5.16.2

--- a/main.go
+++ b/main.go
@@ -2,9 +2,13 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"os/signal"
 	"strconv"
+	"syscall"
+	"time"
 
 	"github.com/app-sre/terraform-repo-executor/pkg"
 )
@@ -21,9 +25,21 @@ const (
 	GitlabToken    = "GITLAB_TOKEN"
 	GitEmail       = "GIT_EMAIL"
 	TfParallelism  = "TF_PARALLELISM"
+	LogFlushDelay  = "LOG_FLUSH_DELAY_SECONDS"
 )
 
 func main() {
+	// Generate unique session ID for Vector log tracking
+	sessionID := fmt.Sprintf("session-%d", time.Now().UnixNano())
+
+	log.Printf("Starting terraform-repo-executor [%s]", sessionID)
+
+	// Setup graceful shutdown handling
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
+
+	done := make(chan error, 1)
+
 	cfgPath := getEnvOrDefault(ConfigFile, "/config.yaml")
 	workdir := getEnvOrDefault(WorkDir, "/tmp/tf-repo")
 	vaultAddr := getEnvOrError(VaultAddr)
@@ -34,28 +50,61 @@ func main() {
 	gitlabToken := getEnvOrError(GitlabToken)
 	gitEmail := getEnvOrError(GitEmail)
 	tfParallelism := getEnvOrDefault(TfParallelism, "10")
+	logFlushDelay := getEnvOrDefault(LogFlushDelay, "3")
 
 	tfParallelismInt, err := strconv.Atoi(tfParallelism)
-
 	if err != nil {
 		log.Fatal("Integer value required for `TF_PARALLELISM` environment variable")
 	}
 
-	err = pkg.Run(cfgPath,
-		workdir,
-		vaultAddr,
-		roleID,
-		secretID,
-		gitlabLogRepo,
-		gitlabUsername,
-		gitlabToken,
-		gitEmail,
-		tfParallelismInt,
-	)
+	logFlushDelayInt, err := strconv.Atoi(logFlushDelay)
 	if err != nil {
-		log.Fatalln(err)
+		logFlushDelayInt = 3
 	}
+
+	// Run main logic in goroutine
+	go func() {
+		err := pkg.Run(cfgPath,
+			workdir,
+			vaultAddr,
+			roleID,
+			secretID,
+			gitlabLogRepo,
+			gitlabUsername,
+			gitlabToken,
+			gitEmail,
+			tfParallelismInt,
+		)
+		done <- err
+	}()
+
+	// Wait for completion or signal
+	select {
+	case err := <-done:
+		if err != nil {
+			log.Printf("Error: %v [%s]", err, sessionID)
+			performGracefulShutdown(sessionID, logFlushDelayInt)
+			os.Exit(1)
+		}
+		log.Printf("Completed successfully [%s]", sessionID)
+	case sig := <-sigChan:
+		log.Printf("Received signal %v, shutting down [%s]", sig, sessionID)
+	}
+
+	performGracefulShutdown(sessionID, logFlushDelayInt)
 	os.Exit(0)
+}
+
+func performGracefulShutdown(sessionID string, delaySeconds int) {
+	// Add minimal logging noise to help Vector fingerprinting
+	log.Printf("Shutting down [%s] - %s", sessionID, time.Now().Format(time.RFC3339))
+
+	// Brief delay for log collection
+	if delaySeconds > 0 {
+		time.Sleep(time.Duration(delaySeconds) * time.Second)
+	}
+
+	log.Printf("Shutdown complete [%s]", sessionID)
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/main.go
+++ b/main.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"os/signal"
 	"strconv"
-	"syscall"
 	"time"
 
 	"github.com/app-sre/terraform-repo-executor/pkg"
@@ -25,7 +23,6 @@ const (
 	GitlabToken    = "GITLAB_TOKEN"
 	GitEmail       = "GIT_EMAIL"
 	TfParallelism  = "TF_PARALLELISM"
-	LogFlushDelay  = "LOG_FLUSH_DELAY_SECONDS"
 )
 
 func main() {
@@ -33,12 +30,6 @@ func main() {
 	sessionID := fmt.Sprintf("session-%d", time.Now().UnixNano())
 
 	log.Printf("Starting terraform-repo-executor [%s]", sessionID)
-
-	// Setup graceful shutdown handling
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGTERM, syscall.SIGINT)
-
-	done := make(chan error, 1)
 
 	cfgPath := getEnvOrDefault(ConfigFile, "/config.yaml")
 	workdir := getEnvOrDefault(WorkDir, "/tmp/tf-repo")
@@ -50,61 +41,33 @@ func main() {
 	gitlabToken := getEnvOrError(GitlabToken)
 	gitEmail := getEnvOrError(GitEmail)
 	tfParallelism := getEnvOrDefault(TfParallelism, "10")
-	logFlushDelay := getEnvOrDefault(LogFlushDelay, "3")
 
 	tfParallelismInt, err := strconv.Atoi(tfParallelism)
 	if err != nil {
 		log.Fatal("Integer value required for `TF_PARALLELISM` environment variable")
 	}
 
-	logFlushDelayInt, err := strconv.Atoi(logFlushDelay)
+	err = pkg.Run(cfgPath,
+		workdir,
+		vaultAddr,
+		roleID,
+		secretID,
+		gitlabLogRepo,
+		gitlabUsername,
+		gitlabToken,
+		gitEmail,
+		tfParallelismInt,
+	)
+
+	// sleep to let vector flush logs
+	time.Sleep(2 * time.Second)
+
 	if err != nil {
-		logFlushDelayInt = 3
+		log.Printf("Error: %v [%s]", err, sessionID)
+		os.Exit(1)
 	}
-
-	// Run main logic in goroutine
-	go func() {
-		err := pkg.Run(cfgPath,
-			workdir,
-			vaultAddr,
-			roleID,
-			secretID,
-			gitlabLogRepo,
-			gitlabUsername,
-			gitlabToken,
-			gitEmail,
-			tfParallelismInt,
-		)
-		done <- err
-	}()
-
-	// Wait for completion or signal
-	select {
-	case err := <-done:
-		if err != nil {
-			log.Printf("Error: %v [%s]", err, sessionID)
-			performGracefulShutdown(sessionID, logFlushDelayInt)
-			os.Exit(1)
-		}
-		log.Printf("Completed successfully [%s]", sessionID)
-	case sig := <-sigChan:
-		log.Printf("Received signal %v, shutting down [%s]", sig, sessionID)
-	}
-
-	performGracefulShutdown(sessionID, logFlushDelayInt)
+	log.Printf("Completed successfully [%s]", sessionID)
 	os.Exit(0)
-}
-
-func performGracefulShutdown(sessionID string, delaySeconds int) {
-	// Add minimal logging noise to help Vector fingerprinting
-	log.Printf("Shutting down [%s] - %s", sessionID, time.Now().Format(time.RFC3339))
-
-	// Brief delay for log collection
-	if delaySeconds > 0 {
-		time.Sleep(time.Duration(delaySeconds) * time.Second)
-	}
-
-	log.Printf("Shutdown complete [%s]", sessionID)
 }
 
 func getEnvOrDefault(key, defaultValue string) string {

--- a/pkg/execute.go
+++ b/pkg/execute.go
@@ -112,7 +112,9 @@ func Run(cfgPath,
 	}
 
 	errCounter := 0
-	for _, repo := range cfg.Repos {
+	for i, repo := range cfg.Repos {
+		log.Printf("Processing repository %s (%d/%d)", repo.Name, i+1, len(cfg.Repos))
+
 		// there needs to be a clean working directory for each repository
 		err := os.Mkdir(workdir, FolderPerm)
 		if err != nil {

--- a/renovate.json
+++ b/renovate.json
@@ -4,5 +4,13 @@
   "gomod": {
     "enabled": true
   },
-  "postUpdateOptions": ["gomodTidy"]
+  "postUpdateOptions": ["gomodTidy"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["golang"],
+      "matchFileNames": [".tool-versions", "go.mod", "Dockerfile"],
+      "groupName": "golang",
+      "groupSlug": "golang"
+    }
+  ]
 }


### PR DESCRIPTION
- Pins the repo to golang 1.24.6
- Also updates the renovate config so that golang updates are properly grouped together
- Implements a light workaround for a Vector issue with short lived pod logs: https://issues.redhat.com/browse/LOG-7075, https://github.com/vectordotdev/vector/issues/1065

Co-authored with Claude Code