### PR TITLE
Revert "Validate that users are using an S3 backend by pulling the statefile"

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,6 @@ require (
 	github.com/ryanuber/go-glob v1.0.0 // indirect
 	github.com/sergi/go-diff v1.4.0 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect
-	github.com/stretchr/objx v0.5.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.3 // indirect
 	github.com/zclconf/go-cty v1.16.3 // indirect
 	golang.org/x/crypto v0.41.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,6 @@ github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic
 github.com/skeema/knownhosts v1.3.1 h1:X2osQ+RAjK76shCbvhHHHVl3ZlgDm8apHEHFqRjnBY8=
 github.com/skeema/knownhosts v1.3.1/go.mod h1:r7KTdC8l4uxWRyK2TpQZ/1o5HaSzh06ePQNxPwTcfiY=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/pkg/terraform.go
+++ b/pkg/terraform.go
@@ -3,7 +3,6 @@ package pkg
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -20,11 +19,6 @@ type TfCreds struct {
 	Region    string
 	Key       string // set when initializing backend
 	Bucket    string
-}
-
-// TerraformExecutor interface wraps terraform functionality for testing & mocking
-type TerraformExecutor interface {
-	StatePull(ctx context.Context, opts ...tfexec.StatePullOption) (string, error)
 }
 
 // standardized AppSRE terraform secret keys
@@ -194,38 +188,6 @@ func (e *Executor) fipsComplianceCheck(repo Repo, planFile string, tf *tfexec.Te
 	return nil
 }
 
-// validateS3Backend ensures that the repo is using an S3 backend by pulling and examining the statefile after initializing the repo
-func (e *Executor) validateS3Backend(tf TerraformExecutor, repo Repo) error {
-	state, err := tf.StatePull(context.Background())
-	if err != nil {
-		return fmt.Errorf("failed to pull terraform state for repo '%s': %w", repo.Name, err)
-	}
-
-	if len(state) == 0 {
-		return fmt.Errorf("repository '%s' has empty terraform state, which indicates no S3 backend is configured", repo.Name)
-	}
-
-	var stateData map[string]interface{}
-	if err := json.Unmarshal([]byte(state), &stateData); err != nil {
-		return fmt.Errorf("failed to parse terraform state for repo '%s': %w", repo.Name, err)
-	}
-
-	backend, ok := stateData["backend"].(map[string]interface{})
-	if !ok {
-		return fmt.Errorf("repository '%s' does not have backend configuration in terraform state", repo.Name)
-	}
-
-	backendType, ok := backend["type"].(string)
-	if !ok {
-		return fmt.Errorf("repository '%s' has invalid backend type in terraform state", repo.Name)
-	}
-
-	if backendType != "s3" {
-		return fmt.Errorf("repository '%s' is using backend type '%s' instead of required S3 backend", repo.Name, backendType)
-	}
-	return nil
-}
-
 // performs a terraform show without the `-json` flag to workaround the fact that the tfexec package
 // only supports outputting the state as JSON which exposes sensitive values
 func (e *Executor) showRaw(dir string, tfBinaryLocation string) (string, error) {
@@ -257,13 +219,6 @@ func (e *Executor) processTfPlan(repo Repo, dryRun bool, envVars map[string]stri
 	if err != nil {
 		return nil, err
 	}
-
-	// Validate that S3 backend is configured
-	err = e.validateS3Backend(tf, repo)
-	if err != nil {
-		return nil, err
-	}
-
 	tf.SetStdout(os.Stdout)
 	tf.SetStderr(os.Stderr)
 


### PR DESCRIPTION
Reverts app-sre/terraform-repo-executor#88

This is matching on PRs that have a valid statefile.